### PR TITLE
cherrypy 18.9.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/repoze.lru-feedstock/pr2/48ae09b
+  - https://staging.continuum.io/prefect/fs/routes-feedstock/pr2/e06793e

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/repoze.lru-feedstock/pr2/48ae09b
-  - https://staging.continuum.io/prefect/fs/routes-feedstock/pr2/e06793e

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
     - setuptools_scm >=3.5
     - toml
     - wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,6 @@ requirements:
     - jaraco.collections
     - pywin32 >=227   # [win and py<310]
     - importlib-metadata # [py<38]
-  run_constrained:
     - simplejson
     - routes >=2.3.1
     - pyopenssl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,11 +23,12 @@ requirements:
     - wheel
   run:
     - python
-    - more-itertools
     - cheroot >=8.2.1
     - portend >=2.1.1
+    - more-itertools
     - zc.lockfile
     - jaraco.collections
+  run_constrained:
     - simplejson
     - routes >=2.3.1
     - pyopenssl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   skip: true  # [py<36 or s390x]
   entry_points:
     - cherryd = cherrypy.__main__:run
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,11 +28,11 @@ requirements:
     - more-itertools
     - zc.lockfile
     - jaraco.collections
+    - pywin32 >=227   # [win and py<310]
   run_constrained:
     - simplejson
     - routes >=2.3.1
     - pyopenssl
-    - pywin32 >=227   # [win and py<310]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,8 @@ requirements:
   host:
     - python
     - pip
-    - setuptools_scm
+    - setuptools_scm >=3.5
+    - toml
     - wheel
   run:
     - python
@@ -29,6 +30,7 @@ requirements:
     - zc.lockfile
     - jaraco.collections
     - pywin32 >=227   # [win and py<310]
+    - importlib-metadata # [py<38]
   run_constrained:
     - simplejson
     - routes >=2.3.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "18.8.0" %}
+{% set version = "18.9.0" %}
 
 package:
   name: cherrypy
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/C/CherryPy/CherryPy-{{ version }}.tar.gz
-  sha256: 9b48cfba8a2f16d5b6419cc657e6d51db005ba35c5e3824e4728bb03bbc7ef9b
+  sha256: 6b06c191ce71a86461f30572a1ab57ffc09f43143ba8e42c103c7b3347220eb1
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4672](https://anaconda.atlassian.net/browse/PKG-4672)
- [Upstream repository](https://github.com/cherrypy/cherrypy/tree/v18.9.0)
- [Upstream changelog/diff](https://github.com/cherrypy/cherrypy/blob/v18.9.0/CHANGES.rst)

### Explanation of changes:

- Update version
- Move extra packages to `run_constrained`

[PKG-4672]: https://anaconda.atlassian.net/browse/PKG-4672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ